### PR TITLE
Add Full Customize Configuration

### DIFF
--- a/plugin/lazyLoad/jquery.lazyload.js
+++ b/plugin/lazyLoad/jquery.lazyload.js
@@ -20,7 +20,10 @@
             event           : "scroll",
             effect          : "show",
             container       : window,
-            skip_invisible  : true
+            skip_invisible  : true,
+            attr_dest       : "src",        /*define which attribute should be updated*/
+            attr_src        : "original",   /*define which attribute/data should be updating source*/
+            use_data        : true          /*use data or attribute as attr_src switch*/
         };
                 
         if(options) {
@@ -69,15 +72,15 @@
             /* When appear is triggered load original image. */
             $(self).one("appear", function() {
                 if (!this.loaded) {
-                    $("<img />")
+                    $(this)
                         .bind("load", function() {
                             $(self)
                                 .hide()
-                                .attr("src", $(self).data("original"))
+                                .attr(settings.attr_dest, settings.use_data?$(self).data(settings.attr_src):$(self).attr(settings.attr_src))
                                 [settings.effect](settings.effectspeed);
                             self.loaded = true;
                         })
-                        .attr("src", $(self).data("original"));
+                        .attr(settings.attr_dest, settings.use_data?$(self).data(settings.attr_src):$(self).attr(settings.attr_src));
                 };
             });
 


### PR DESCRIPTION
I added full customize configuration, so jquery.lazyload.js can be applied to any attribute of any html tag. I've already applied it to my project: The implement of lazy loading of video tag's poster attribute using the following configurations and video tag:
$(document).ready(function() {
	$('video[data-lazy]').lazyload({ 
		threshold:480, 
		failure_limit:2, 
		attr_dest:'poster',
		attr_src:'lazy'
	});
});
<video id="video" controls="" preload="none" x5-video-player-type="h5-page" poster="" data-lazy="xxx.jpg" width="100%" >
	<source src="xxx.mp4" type="video/mp4">
	浏览器不支持H5视频
</video>
I wish this could help u to make any attribute of any tags to lazy load easily!